### PR TITLE
OT194-83 - Formulario Testimonios

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -4,6 +4,7 @@ import activitiesSlice from '../features/activities/activitiesSlice';
 import alertSlice from '../features/alert/alertSlice';
 import newsSlice from '../features/news/newsSlice';
 import componentsSlice from '../features/components/componentsSlice';
+import testimonialssSlice from '../features/testimonials/testimonialsSlice';
 
 export default configureStore({
 	reducer: {
@@ -11,6 +12,7 @@ export default configureStore({
 		news: newsSlice,
 		auth: authSlice,
 		activities: activitiesSlice,
-		components: componentsSlice
+		components: componentsSlice,
+		testimonials: testimonialssSlice
 	}
 });

--- a/src/components/share/Forms/TestimonialsForm/index.js
+++ b/src/components/share/Forms/TestimonialsForm/index.js
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react';
+import { CKEditor } from '@ckeditor/ckeditor5-react';
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import { PropTypes } from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { testimonialsFormSchema } from '../../Forms/TestimonialsForm/schemaTestimonialsForm';
+import '../../../../custom.css';
+
+import {
+	modifyTestimony,
+	createTestimony,
+	testimonialsActions
+	// getTestimony
+} from '../../../../features/testimonials/testimonialsSlice';
+import { useParams } from 'react-router-dom';
+import { Field, Form, Formik } from 'formik';
+
+const supportedMimeTypes = ['image/jpeg', 'image/png', 'image/jpg'];
+
+export const TestimonialsForm = () => {
+	/* TODO:
+    Falta testear la conexion con los endpoints
+    Falta traer el testimonio correctamente
+    Falta subir la imagen correctamente
+  */
+
+	const testimony = useSelector(state => state.testimonials.openedTestimony);
+
+	const [image, setImage] = useState(undefined);
+	const [imgError, setImgError] = useState(false);
+	const dispatch = useDispatch();
+
+	const { id: testimonyId } = useParams();
+
+	useEffect(() => {
+	// 	dispatch(getTestimony(testimonyId));
+	}, []);
+
+	const handleSubmit = (data) => {
+		setImgError(false);
+
+		if (!image) return setImgError(true);
+
+		if (image && (image.size > 50936250 || !supportedMimeTypes.includes(image.type))) {
+			return setImgError(true);
+		}
+
+		if (testimonyId >= 0 && testimony.name.length > 0) {
+			dispatch(modifyTestimony(testimonyId, data, image));
+		} else {
+			dispatch(createTestimony(data, image));
+		}
+
+		dispatch(testimonialsActions.resetOpenedNews());
+	};
+
+	return (
+		<div
+			className='mx-auto'
+			style={{
+				maxWidth: '1000px',
+				width: '80%'
+			}}
+		>
+			<Formik
+				enableReinitialize
+				validationSchema={testimonialsFormSchema}
+				initialValues={testimony}
+				onSubmit={handleSubmit}
+			>
+				{({ errors, setFieldValue, values }) => (
+					<Form className="flex flex-col">
+						<div className="flex flex-col gap-1 mb-3">
+							<label>Imagen</label>
+							<input
+								type="file"
+								name='logo'
+								onChange={(e) => setImage(e.target.files[0])}
+								placeholder='Logo'
+							/>
+							{imgError ? <div className="text-red-800 font-bold my-1">Archivo faltante o no soportado</div> : null}
+						</div>
+						<div className="flex flex-col gap-1 mb-3">
+							<label>Nombre</label>
+							<Field
+								className="form-login p-3"
+								type="text"
+								name="name"
+							/>
+							{errors.name ? <div className="text-red-800 font-bold my-1">{errors.name}</div> : null}
+						</div>
+						<div className="flex flex-col gap-1 mb-3">
+							<label>Contenido</label>
+							<CKEditor
+								editor={ClassicEditor}
+								config={{
+									toolbar: {
+										items: [
+											'heading',
+											'|',
+											'|',
+											'bold',
+											'italic',
+											'|',
+											'link',
+											'|',
+											'bulletedList',
+											'numberedList',
+											'|',
+											'|',
+											'insertTable',
+											'|',
+											'outdent',
+											'indent',
+											'blockQuote',
+											'|',
+											'undo',
+											'redo'
+										],
+										shouldNotGroupWhenFull: true
+									}
+								}}
+								data={values.content}
+								onChange={(event, editor) => {
+									const data = editor.getData();
+									setFieldValue('content', data);
+								}}
+							/>
+							{errors.content ? <div className="text-red-800 font-bold my-1">{errors.content}</div> : null}
+						</div>
+						<button
+							type='submit'
+							className='mt-3 text-white bg-redOng hover:bg-redOng focus:ring rounded border-0 py-3 px-6 cursor-pointer hover:opacity-50'
+						>
+							{(testimonyId > 0 && testimony.name.length > 0) ? 'Modificar' : 'Crear'}
+						</button>
+					</Form>
+				)}
+			</Formik>
+		</div>
+	);
+};
+
+TestimonialsForm.propTypes = {
+	testimony: PropTypes.shape({
+		id: PropTypes.string,
+		name: PropTypes.string,
+		image: PropTypes.string,
+		content: PropTypes.string,
+		category: PropTypes.string
+	})
+};

--- a/src/components/share/Forms/TestimonialsForm/schemaTestimonialsForm.js
+++ b/src/components/share/Forms/TestimonialsForm/schemaTestimonialsForm.js
@@ -1,0 +1,8 @@
+import * as Yup from 'yup';
+const required = 'es un campo requerido';
+const length = 'debe tener al menos 6 caracteres';
+
+export const testimonialsFormSchema = Yup.object().shape({
+	name: Yup.string().min(6, `El nombre ${length}`).required(`El nombre ${required}`),
+	content: Yup.string().required(`El contenido ${required}`)
+});

--- a/src/features/testimonials/testimonialsSlice.js
+++ b/src/features/testimonials/testimonialsSlice.js
@@ -1,0 +1,130 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { axiosInstance } from '../../helper/axiosInstance';
+
+const initialState = {
+	openedTestimony: {
+		name: '',
+		image: '',
+		content: ''
+	},
+	isError: false,
+	isSuccess: false,
+	isLoading: false,
+	message: ''
+};
+
+// Obtener un testimonio en especifico
+export const getTestimony = createAsyncThunk(
+	'testimonials/getData',
+	async (id, thunkAPI) => {
+		try {
+			return axiosInstance(`/testimonials/${id}`, {}, 'GET');
+		} catch (error) {
+			const message =
+				(error.response &&
+					error.response.data &&
+					error.response.data.message) ||
+				error.message ||
+				error.toString();
+			return thunkAPI.rejectWithValue(message);
+		}
+	}
+);
+
+// Crear un testimonio
+export const createTestimony = createAsyncThunk(
+	'testimonials/createData',
+	async (data, image, thunkAPI) => {
+		try {
+			if (image) {
+				// logica para subir imagen
+			}
+			return axiosInstance('/testimonials', data, 'POST');
+		} catch (error) {
+			const message =
+				(error.response &&
+					error.response.data &&
+					error.response.data.message) ||
+				error.message ||
+				error.toString();
+			return thunkAPI.rejectWithValue(message);
+		}
+	}
+);
+
+// Editar un testimonio
+export const modifyTestimony = createAsyncThunk(
+	'testimonials/modifyData',
+	async (id, data, image, thunkAPI) => {
+		try {
+			if (image) {
+				// logica para subir imagen
+			}
+			return axiosInstance(`/testimonials/${id}`, data, 'PATCH');
+		} catch (error) {
+			const message =
+				(error.response &&
+					error.response.data &&
+					error.response.data.message) ||
+				error.message ||
+				error.toString();
+			return thunkAPI.rejectWithValue(message);
+		}
+	}
+);
+
+export const testimonialsSlice = createSlice({
+	name: 'testimonials',
+	initialState,
+	reducers: {
+		resetOpenedNews: (state) => {
+			state.openedTestimony = initialState.openedTestimony;
+		}
+	},
+	extraReducers: (builder) => {
+		builder
+			// Get
+			.addCase(getTestimony.pending, (state) => {
+				state.isLoading = true;
+			})
+			.addCase(getTestimony.fulfilled, (state, action) => {
+				state.isLoading = false;
+				state.isSuccess = true;
+				state.openedTestimony = action.payload;
+			})
+			.addCase(getTestimony.rejected, (state, action) => {
+				state.isLoading = false;
+				state.isError = true;
+				state.message = action.payload;
+			})
+			// Create
+			.addCase(createTestimony.pending, (state) => {
+				state.isLoading = true;
+			})
+			.addCase(createTestimony.fulfilled, (state, action) => {
+				state.isLoading = false;
+				state.isSuccess = true;
+			})
+			.addCase(createTestimony.rejected, (state, action) => {
+				state.isLoading = false;
+				state.isError = true;
+				state.message = action.payload;
+			})
+			// Modify
+			.addCase(modifyTestimony.pending, (state) => {
+				state.isLoading = true;
+			})
+			.addCase(modifyTestimony.fulfilled, (state, action) => {
+				state.isLoading = false;
+				state.isSuccess = true;
+			})
+			.addCase(modifyTestimony.rejected, (state, action) => {
+				state.isLoading = false;
+				state.isError = true;
+				state.message = action.payload;
+			});
+	}
+});
+
+export const testimonialsActions = testimonialsSlice.actions;
+export default testimonialsSlice.reducer;


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT194-83

## Que hace este PR?
Se creo el componente de formulario reutilizable para testimonios.
Se creo el slice para los testimonios y las acciones necesarias para manejar el Post y el Patch cuando estos tengan endpoints funcionales

## Donde esta la modificacion principal?
En ./features/testimonials/testimonialsSlice.js
y en ./share/Forms/TestimonialsForm

## Quedo algo pendiente?
En un futuro se debe corregir el como se envia la imagen al backend.
Todavía no hay conexiones con el backend, pero estan preparadas las funciones para cuando estos existan.

## Adjunto imagen de lo realizado
![image](https://user-images.githubusercontent.com/68754287/172894832-a9626f46-5034-4d7d-9145-4270881ece42.png)
